### PR TITLE
Fix branch name

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: "pplox CI"
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     tags:
       - "*.*.*"
 


### PR DESCRIPTION
CodeCrafters system expects `master` as the default branch.