### PR TITLE
Reuse pytest job in workflows

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,23 +9,8 @@ on:
 jobs:
   test:
     name: Test pplox
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install pytest
-        run: >-
-          python3 -m
-          pip install
-          pytest
-          --user
-      - name: Run tests
-        run: >-
-          python3 -m pytest .
-
+    uses: ./.github/workflows/pytest.yml
+    
   build-package:
     name: Build pplox package
     needs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,19 +6,4 @@ on:
 jobs:
   test:
     name: Pre-merge tests 
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install pytest
-        run: >-
-          python3 -m
-          pip install
-          pytest
-          --user
-      - name: Run tests
-        run: >-
-          python3 -m pytest .
+    uses: ./.github/workflows/pytest.yml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,24 @@
+name: Run pytest
+
+on:
+  workflow_call: 
+
+jobs:
+  test:
+    name: Run pytest 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install pytest
+        run: >-
+          python3 -m
+          pip install
+          pytest
+          --user
+      - name: Run tests
+        run: >-
+          python3 -m pytest .


### PR DESCRIPTION
We previously were using duplicated pytest code in `cicd.yml` and `pytest.yml`. By using reusable workflows we reduce the amount of duplication. 

Doc: https://docs.github.com/en/actions/sharing-automations/reusing-workflows