### PR TITLE
Fix PyPI upload jobs by bumping download-artifact

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -79,7 +79,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -121,7 +121,7 @@ jobs:
       id-token: write
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
We updated `upload-artifact` in https://github.com/karlcaga/pplox/commit/400d2bd1f8393bc820a178090fe7bd5405333f7d but forgot to update `download-artifact` in the PyPI jobs